### PR TITLE
use django storage backend and work around issues with redirecting output to a file

### DIFF
--- a/fixturemedia/management/commands/dumpdata.py
+++ b/fixturemedia/management/commands/dumpdata.py
@@ -2,18 +2,24 @@ from optparse import make_option
 import os
 from os.path import abspath, dirname, exists, join
 
-from django.conf import settings
 from django.core.management.base import CommandError
 import django.core.management.commands.dumpdata
 import django.core.serializers
 from django.db.models.fields.files import FileField
 import django.dispatch
 from django.core.files.storage import default_storage
+from django.core.files.base import File
 
 from fixturemedia.management.commands.loaddata import models_with_filefields
 
 
 pre_dump = django.dispatch.Signal(providing_args=('instance',))
+
+
+class FileOutput(File):
+    def __init__(self, file, name=None):
+        self.ending = None
+        return super(FileOutput, self).__init__(file, name)
 
 
 class Command(django.core.management.commands.dumpdata.Command):
@@ -79,6 +85,6 @@ class Command(django.core.management.commands.dumpdata.Command):
             pre_dump.connect(self.save_images_for_signal, sender=modelclass)
 
         self.set_up_serializer(ser_format)
-        if True:
-        #with open(outfilename, 'w') as self.stdout:
+
+        with FileOutput(open(outfilename, 'w')) as self.stdout:
             super(Command, self).handle(*app_labels, **options)

--- a/fixturemedia/management/commands/dumpdata.py
+++ b/fixturemedia/management/commands/dumpdata.py
@@ -1,8 +1,6 @@
 from optparse import make_option
 import os
 from os.path import abspath, dirname, exists, join
-import shutil
-from cStringIO import StringIO
 
 from django.conf import settings
 from django.core.management.base import CommandError
@@ -28,7 +26,6 @@ class Command(django.core.management.commands.dumpdata.Command):
     def save_images_for_signal(self, sender, **kwargs):
         instance = kwargs['instance']
         for field in sender._meta.fields:
-            print "ping"
             if not isinstance(field, FileField):
                 continue
             path = getattr(instance, field.attname)
@@ -37,9 +34,6 @@ class Command(django.core.management.commands.dumpdata.Command):
 
             if not default_storage.exists(path.name):
                 continue
-#            source_path = join(settings.MEDIA_ROOT, path.name)
-#            if not exists(source_path):
-#                continue
 
             target_path = join(self.target_dir, path.name)
             if not exists(dirname(target_path)):
@@ -85,5 +79,6 @@ class Command(django.core.management.commands.dumpdata.Command):
             pre_dump.connect(self.save_images_for_signal, sender=modelclass)
 
         self.set_up_serializer(ser_format)
-        with open(outfilename, 'w') as self.stdout:
+        if True:
+        #with open(outfilename, 'w') as self.stdout:
             super(Command, self).handle(*app_labels, **options)

--- a/fixturemedia/management/commands/dumpdata.py
+++ b/fixturemedia/management/commands/dumpdata.py
@@ -16,12 +16,6 @@ from fixturemedia.management.commands.loaddata import models_with_filefields
 pre_dump = django.dispatch.Signal(providing_args=('instance',))
 
 
-class FileOutput(File):
-    def __init__(self, file, name=None):
-        self.ending = None
-        return super(FileOutput, self).__init__(file, name)
-
-
 class Command(django.core.management.commands.dumpdata.Command):
 
     option_list = django.core.management.commands.dumpdata.Command.option_list + (
@@ -86,5 +80,5 @@ class Command(django.core.management.commands.dumpdata.Command):
 
         self.set_up_serializer(ser_format)
 
-        with FileOutput(open(outfilename, 'w')) as self.stdout:
+        with File(open(outfilename, 'w')) as self.stdout:
             super(Command, self).handle(*app_labels, **options)

--- a/fixturemedia/management/commands/loaddata.py
+++ b/fixturemedia/management/commands/loaddata.py
@@ -42,9 +42,8 @@ class Command(django.core.management.commands.loaddata.Command):
                     self.stderr.write("Expected file at {} doesn't exist, skipping".format(filepath))
                     continue
                 
-                out_file = default_storage.open(target_path, 'w')
-                out_file.write(file_contents)
-                out_file.close()
+                default_storage.save(target_path, file_contents)
+ 
 
 
 

--- a/fixturemedia/management/commands/loaddata.py
+++ b/fixturemedia/management/commands/loaddata.py
@@ -2,6 +2,7 @@ from os.path import dirname, exists, isdir, join, relpath
 
 from django.conf import settings
 import django.core.management.commands.loaddata
+from django.core.files.storage import default_storage
 import django.core.serializers
 from django.db.models import get_apps, get_models, signals
 from django.db.models.fields.files import FileField
@@ -33,14 +34,12 @@ class Command(django.core.management.commands.loaddata.Command):
                 # don't intend, throwing OSErrors for mismatched modes. So
                 # just check if it exists first.
                 try:
-                    in_file = open(filepath, 'r')
-                    file_contents = in_file.read()
-                    in_file.close()
+                    default_storage.save(path.name, open(filepath, 'r'))
                 except FileNotFoundError:
                     self.stderr.write("Expected file at {} doesn't exist, skipping".format(filepath))
                     continue
                 
-                default_storage.save(target_path, file_contents)
+                
  
 
 

--- a/fixturemedia/management/commands/loaddata.py
+++ b/fixturemedia/management/commands/loaddata.py
@@ -1,8 +1,6 @@
-import os
 from os.path import dirname, exists, isdir, join, relpath
 
 from django.conf import settings
-from django.core.files import File
 import django.core.management.commands.loaddata
 import django.core.serializers
 from django.db.models import get_apps, get_models, signals


### PR DESCRIPTION
This uses the django storage backend instead of shutil to copy files. This is important if one uses an alternative storage backend for media files.

It also reenables the automatic output to a file of dumpdata due to errors with the original setup on linux/django 1.6.
